### PR TITLE
Data visualizer - Suggestions for expanded row layout

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/common/components/examples_list/examples_list.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/examples_list/examples_list.tsx
@@ -42,6 +42,7 @@ export const ExamplesList: FC<Props> = ({ examples }) => {
 
   return (
     <ExpandedRowPanel
+      grow={false}
       dataTestSubj="dataVisualizerFieldDataExamplesList"
       className="dataVisualizerTextContent dataVisualizerPanelWrapper"
     >

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/_index.scss
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/_index.scss
@@ -8,6 +8,7 @@ $panelWidthL:     #{'max(40%, 450px)'};
 .dataVisualizerFieldExpandedRow {
   padding-left: $euiSize * 4;
   width: 100%;
+  padding-bottom: $euiSizeM;
 
   .fieldDataCard__valuesTitle {
     text-transform: uppercase;
@@ -52,6 +53,9 @@ $panelWidthL:     #{'max(40%, 450px)'};
   }
 
   .dataVisualizerSummaryTable {
+    table {
+      display: flex;
+    }
     .euiTableRow > .euiTableRowCell {
       border-bottom: 0;
     }
@@ -60,18 +64,8 @@ $panelWidthL:     #{'max(40%, 450px)'};
     }
   }
 
-  .dataVisualizerSummaryTableWrapper {
-    min-width: $panelWidthS;
-    max-width: $panelWidthS;
-  }
-
   .dataVisualizerMapWrapper {
     min-height: 250px;
-    min-width: $panelWidthL;
-  }
-
-  .dataVisualizerTopValuesWrapper {
-    min-width: $panelWidthS;
   }
 
   .dataVisualizerUniformPanel {
@@ -80,11 +74,7 @@ $panelWidthL:     #{'max(40%, 450px)'};
   }
 
   .dataVisualizerPanelWrapper {
-    margin: $euiSizeXS $euiSizeM $euiSizeM 0;
     height: fit-content;
-    &.compressed {
-      width: $panelWidthS;
-    }
   }
 
   .dataVisualizerTextContent {

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/boolean_content.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/boolean_content.tsx
@@ -72,7 +72,6 @@ export const BooleanContent: FC<FieldDataRowProps> = ({ config }) => {
       field: 'function',
       name: '',
       render: (_: string, summaryItem: { display: ReactNode }) => summaryItem.display,
-      width: '25px',
       align: RIGHT_ALIGNMENT as HorizontalAlignment,
     },
     {
@@ -93,7 +92,10 @@ export const BooleanContent: FC<FieldDataRowProps> = ({ config }) => {
     <ExpandedRowContent dataTestSubj={'dataVisualizerBooleanContent'}>
       <DocumentStatsTable config={config} />
 
-      <ExpandedRowPanel className={'dataVisualizerSummaryTableWrapper dataVisualizerPanelWrapper'}>
+      <ExpandedRowPanel
+        grow={false}
+        className={'dataVisualizerSummaryTableWrapper dataVisualizerPanelWrapper'}
+      >
         <ExpandedRowFieldHeader>{summaryTableTitle}</ExpandedRowFieldHeader>
         <EuiBasicTable
           className={'dataVisualizerSummaryTable'}

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/date_content.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/date_content.tsx
@@ -77,7 +77,10 @@ export const DateContent: FC<FieldDataRowProps> = ({ config }) => {
   return (
     <ExpandedRowContent dataTestSubj={'dataVisualizerDateContent'}>
       <DocumentStatsTable config={config} />
-      <ExpandedRowPanel className={'dataVisualizerSummaryTableWrapper dataVisualizerPanelWrapper'}>
+      <ExpandedRowPanel
+        grow={false}
+        className={'dataVisualizerSummaryTableWrapper dataVisualizerPanelWrapper'}
+      >
         <ExpandedRowFieldHeader>{summaryTableTitle}</ExpandedRowFieldHeader>
         <EuiBasicTable<SummaryTableItem>
           className={'dataVisualizerSummaryTable'}

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/document_stats.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/document_stats.tsx
@@ -19,7 +19,6 @@ const metaTableColumns = [
     field: 'function',
     name: '',
     render: (_: string, metaItem: { display: ReactNode }) => metaItem.display,
-    width: '25px',
     align: RIGHT_ALIGNMENT as HorizontalAlignment,
   },
   {
@@ -80,6 +79,7 @@ export const DocumentStatsTable: FC<FieldDataRowProps> = ({ config }) => {
 
   return (
     <ExpandedRowPanel
+      grow={false}
       dataTestSubj={'dataVisualizerDocumentStatsContent'}
       className={'dataVisualizerSummaryTableWrapper dataVisualizerPanelWrapper'}
     >

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/expanded_row_content.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/expanded_row_content.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { FC, ReactNode } from 'react';
-import { EuiFlexGrid } from '@elastic/eui';
+import { EuiFlexGroup } from '@elastic/eui';
 
 interface Props {
   children: ReactNode;
@@ -14,8 +14,8 @@ interface Props {
 }
 export const ExpandedRowContent: FC<Props> = ({ children, dataTestSubj }) => {
   return (
-    <EuiFlexGrid data-test-subj={dataTestSubj} gutterSize={'s'}>
+    <EuiFlexGroup data-test-subj={dataTestSubj} gutterSize={'s'}>
       {children}
-    </EuiFlexGrid>
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/expanded_row_panel.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/expanded_row_panel.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { FC, ReactNode } from 'react';
-import { EuiPanel } from '@elastic/eui';
+import { EuiFlexItem, EuiPanel } from '@elastic/eui';
 import { EuiFlexItemProps } from '@elastic/eui/src/components/flex/flex_item';
 
 interface Props {
@@ -17,15 +17,17 @@ interface Props {
 }
 export const ExpandedRowPanel: FC<Props> = ({ children, dataTestSubj, grow, className }) => {
   return (
-    <EuiPanel
-      data-test-subj={dataTestSubj}
-      hasShadow={false}
-      hasBorder={true}
-      grow={!!grow}
-      className={className ?? ''}
-      paddingSize={'s'}
-    >
-      {children}
-    </EuiPanel>
+    <EuiFlexItem grow={grow}>
+      <EuiPanel
+        data-test-subj={dataTestSubj}
+        hasShadow={false}
+        hasBorder={true}
+        grow={false}
+        className={className ?? ''}
+        paddingSize={'s'}
+      >
+        {children}
+      </EuiPanel>
+    </EuiFlexItem>
   );
 };

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/keyword_content.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/keyword_content.tsx
@@ -44,7 +44,7 @@ export const KeywordContent: FC<FieldDataRowProps> = ({ config }) => {
   return (
     <ExpandedRowContent dataTestSubj={'dataVisualizerKeywordContent'}>
       <DocumentStatsTable config={config} />
-      <TopValues stats={stats} fieldFormat={fieldFormat} barColor="secondary" />
+      <TopValues grow={false} stats={stats} fieldFormat={fieldFormat} barColor="secondary" />
       {EMSSuggestion && stats && <ChoroplethMap stats={stats} suggestion={EMSSuggestion} />}
     </ExpandedRowContent>
   );

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/number_content.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/number_content.tsx
@@ -90,7 +90,6 @@ export const NumberContent: FC<FieldDataRowProps> = ({ config }) => {
     {
       name: '',
       render: (summaryItem: { display: ReactNode }) => summaryItem.display,
-      width: '25px',
       align: RIGHT_ALIGNMENT as HorizontalAlignment,
     },
     {
@@ -111,7 +110,7 @@ export const NumberContent: FC<FieldDataRowProps> = ({ config }) => {
       <DocumentStatsTable config={config} />
       <ExpandedRowPanel
         className={'dataVisualizerSummaryTableWrapper dataVisualizerPanelWrapper'}
-        grow={1}
+        grow={false}
       >
         <ExpandedRowFieldHeader>{summaryTableTitle}</ExpandedRowFieldHeader>
         <EuiBasicTable<SummaryTableItem>

--- a/x-pack/plugins/data_visualizer/public/application/common/components/top_values/top_values.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/top_values/top_values.tsx
@@ -9,7 +9,7 @@ import React, { FC, Fragment } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiProgress, EuiSpacer, EuiText } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n/react';
-
+import { EuiFlexItemProps } from '@elastic/eui/src/components/flex/flex_item';
 import classNames from 'classnames';
 import { roundToDecimalPlace, kibanaFieldFormat } from '../utils';
 import { ExpandedRowFieldHeader } from '../stats_table/components/expanded_row_field_header';
@@ -20,6 +20,7 @@ interface Props {
   stats: FieldVisStats | undefined;
   fieldFormat?: any;
   barColor?: 'primary' | 'secondary' | 'danger' | 'subdued' | 'accent';
+  grow?: EuiFlexItemProps['grow'];
   compressed?: boolean;
 }
 
@@ -32,7 +33,7 @@ function getPercentLabel(docCount: number, topValuesSampleSize: number): string 
   }
 }
 
-export const TopValues: FC<Props> = ({ stats, fieldFormat, barColor, compressed }) => {
+export const TopValues: FC<Props> = ({ stats, fieldFormat, barColor, grow, compressed }) => {
   if (stats === undefined) return null;
   const {
     topValues,
@@ -44,6 +45,7 @@ export const TopValues: FC<Props> = ({ stats, fieldFormat, barColor, compressed 
   const progressBarMax = isTopValuesSampled === true ? topValuesSampleSize : count;
   return (
     <ExpandedRowPanel
+      grow={grow}
       dataTestSubj={'dataVisualizerFieldDataTopValues'}
       className={classNames('dataVisualizerPanelWrapper', compressed ? 'compressed' : undefined)}
     >
@@ -67,20 +69,15 @@ export const TopValues: FC<Props> = ({ stats, fieldFormat, barColor, compressed 
                   max={progressBarMax}
                   color={barColor}
                   size="xs"
+                  valueText={
+                    progressBarMax !== undefined
+                      ? getPercentLabel(value.doc_count, progressBarMax)
+                      : undefined
+                  }
                   label={kibanaFieldFormat(value.key, fieldFormat)}
                   className={classNames('eui-textTruncate', 'topValuesValueLabelContainer')}
                 />
               </EuiFlexItem>
-              {progressBarMax !== undefined && (
-                <EuiFlexItem
-                  grow={false}
-                  className={classNames('eui-textTruncate', 'topValuesPercentLabelContainer')}
-                >
-                  <EuiText size="xs" textAlign="left" color="subdued">
-                    {getPercentLabel(value.doc_count, progressBarMax)}
-                  </EuiText>
-                </EuiFlexItem>
-              )}
             </EuiFlexGroup>
           ))}
         {isTopValuesSampled === true && (


### PR DESCRIPTION
## Summary

Outcome with suggested changes:

<img width="1194" alt="Frame 6" src="https://user-images.githubusercontent.com/4016496/133968957-0669cde9-5d4b-46c3-9cea-1a6c53f4b7b6.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
